### PR TITLE
Linked visible attribute with showFlagInCompact

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -435,6 +435,7 @@ PlasmoidItem {
 					id: svg
 					imagePath: getIconPath(false)
 				}
+				visible:showFlagInCompact
 			}
 
 			QtControls.Label {


### PR DESCRIPTION
Now according to last guidelines. It is as it should be in the first place. 

I linked visible attribute of icon displaying country flag. Because i think that if someone uncheck:
<img width="228" height="36" alt="image" src="https://github.com/user-attachments/assets/41527bfc-0179-42f9-837c-4a90bd348d3f" />

In most cases doesn't expect change flag to globus icon which still takes some space from panel.