### PR TITLE
feat: add external trigger-file mechanism for data refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ By default, the widget update itself every 5 minutes. You can change this behavi
 
 You can change the colors of the displayed informations in the settings.
 
+### External Refresh Trigger
+
+You can configure a trigger file path in the widget settings. When this file is modified (e.g., via `touch`), the widget will automatically refresh the IP information. This is useful for integrating with VPN scripts or tools like Tailscale that don't use NetworkManager.
+
+Example usage:
+```bash
+# Set trigger file in widget settings to: ~/.cache/ip_address_refresh
+
+# Then trigger a refresh from CLI:
+touch ~/.cache/ip_address_refresh
+
+# Or integrate with Tailscale:
+tailscale set --exit-node=mynode && sleep 2 && touch ~/.cache/ip_address_refresh
+```
+
 This widget uses the [excellent flags icon pack by lipis and contributors](https://github.com/lipis/flag-icon-css).
 
 ![tooltip screenshot](screenshots/screenshot_4.png)

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -36,6 +36,9 @@
         <entry name="sendNotifOnIPChange" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="triggerFile" type="String">
+            <default>~/.cache/ip_address_refresh</default>
+        </entry>
     </group>
 
     <group name="Appearance">

--- a/package/contents/ui/config/configGeneral.qml
+++ b/package/contents/ui/config/configGeneral.qml
@@ -39,6 +39,7 @@ KCM.SimpleKCM {
     property alias cfg_showVPNIcon: showVPNIcon.checked
     property alias cfg_vpnKeywords: vpnKeywordsEdit.text
     property alias cfg_sendNotifOnIPChange: sendNotificationOnIpChange.checked
+    property alias cfg_triggerFile: triggerFileEdit.text
 
     Kirigami.FormLayout {
 
@@ -141,6 +142,22 @@ KCM.SimpleKCM {
         QtControls.CheckBox {
             id: sendNotificationOnIpChange
             text: i18n("Send notification on IP change")
+        }
+
+        Item { // tighten layout
+            Layout.fillHeight: true
+        }
+
+        QtControls.TextField {
+            id: triggerFileEdit
+            Kirigami.FormData.label: i18n("Trigger file (optional):")
+            placeholderText: "~/.cache/ip_address_refresh"
+        }
+
+        QtControls.Label {
+            text: i18n("Touch this file to trigger a refresh")
+            font: Kirigami.Theme.smallFont
+            opacity: 0.7
         }
     }
 


### PR DESCRIPTION
This PR adds the ability to trigger an IP refresh from the command line by touching a configurable trigger file. This is useful for users of VPNs that don't use NetworkManager (like Tailscale, WireGuard, etc.) who want the widget to update when their VPN state changes.

Example:
```bash
tailscale set --exit-node=mynode && touch ~/.cache/ip_address_refresh
```